### PR TITLE
Fix extension import on modern setuptools and keep test suite working across current Sphinx versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.6"
 requires = [
     "sphinx",
     "requests>=2.4.2",
+    "importlib_metadata; python_version < '3.8'",
 ]
 
 [tool.flit.metadata.requires-extra]

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
     install_requires=[
         "sphinx",
         "requests>=2.4.2",
-        "pyyaml"
+        "pyyaml",
+        "importlib_metadata; python_version < '3.8'",
     ],
     extras_require={
         "code": ["black", "flake8", "mypy"],

--- a/sphinxcontrib/kroki/__init__.py
+++ b/sphinxcontrib/kroki/__init__.py
@@ -10,9 +10,15 @@ from typing import Any, Dict
 from sphinx.application import Sphinx
 from .kroki import Kroki
 from .transform import KrokiToImageTransform
-import pkg_resources
 
-__version__ = pkg_resources.get_distribution("sphinxcontrib-kroki").version
+# Python >=3.8 provides importlib.metadata in stdlib.
+# Keep a backport fallback for supported Python 3.6/3.7.
+try:
+    from importlib.metadata import version as _dist_version
+except ImportError:  # pragma: no cover
+    from importlib_metadata import version as _dist_version  # type: ignore
+
+__version__ = _dist_version("sphinxcontrib-kroki")
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
 import os
 import shutil
+from pathlib import Path
 
 import docutils
 import pytest
 
 import sphinx
-from sphinx.testing.path import path
 
 pytest_plugins = "sphinx.testing.fixtures"
 
@@ -15,7 +15,7 @@ collect_ignore = ["fixtures"]
 
 @pytest.fixture(scope="session")
 def rootdir():
-    return path(__file__).parent.abspath() / "fixtures"
+    return Path(__file__).resolve().parent / "fixtures"
 
 
 def pytest_report_header(config):

--- a/tests/test_kroki.py
+++ b/tests/test_kroki.py
@@ -7,14 +7,15 @@
 import re
 import pytest
 from sphinx.application import Sphinx
-from sphinx.testing.path import path
 
 
 def get_content(app: Sphinx) -> str:
     app.builder.build_all()
 
     index = app.outdir / "index.html"
-    return index.read_text() if "read_text" in path.__dict__ else index.text()
+    if hasattr(index, "read_text"):
+        return index.read_text(encoding="utf-8")
+    return index.text()
 
 
 @pytest.mark.sphinx(
@@ -45,5 +46,8 @@ def test_kroki_html(app, status, warning):
     )
     assert re.search(html, content, re.S)
 
-    html = r'<img.*?class="kroki kroki-ditaa align-right".*?/>'
+    html = (
+        r'<img[^>]*class="(?=[^"]*\bkroki\b)'
+        r'(?=[^"]*\bkroki-ditaa\b)(?=[^"]*\balign-right\b)[^"]*"[^>]*/>'
+    )
     assert re.search(html, content, re.S)


### PR DESCRIPTION
Improves compatibility with newer Python packaging environments by switching to the modern metadata-based version lookup, while preserving support for the project’s currently supported Python versions.
